### PR TITLE
Removed KillMode=process

### DIFF
--- a/files/awslogs.service
+++ b/files/awslogs.service
@@ -5,7 +5,6 @@ After=rc-local.service
 [Service]
 Type=simple
 Restart=always
-KillMode=process
 TimeoutSec=infinity
 PIDFile=/var/awslogs/state/awslogs.pid
 ExecStart=/var/awslogs/bin/awslogs-agent-launcher.sh --start --background --pidfile $PIDFILE --user awslogs --chuid awslogs &


### PR DESCRIPTION
When we stop or restart systemd service won't kill awslogs child processes if KillMode is set to process.