### PR TITLE
Start awslogs on boot

### DIFF
--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -4,5 +4,5 @@
   become: True
 
 - name: "awslogs | Start the service"
-  systemd: name=awslogs state=started
+  systemd: name=awslogs state=started enabled=yes
   become: True

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -4,5 +4,9 @@
   become: True
 
 - name: "awslogs | Start the service"
-  systemd: name=awslogs state=started enabled=yes
+  systemd: name=awslogs.service state=started enabled=yes
+  become: True
+
+- name: "awslogs | Start the service on boot"
+  systemd: name=awslogs.service enabled=yes
   become: True


### PR DESCRIPTION
It's usefull when we are baking AMI's with packer